### PR TITLE
46 probability

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,14 +394,16 @@ Results:
 ## Example: Calculating Probability
 To calculate the probability of getting heads when flipping a fair coin, you can use the following command:
 ```shell
-rusty-finance probability --successes 1 --trials 1
+rusty-finance probability --successes 3 --trials 5
 ```
 ### Result
 ```
++-----------+--------+-------------+
+| Successes | Trials | Probability |
++-----------+--------+-------------+
+| 3         | 5      | 60.00%      |
++-----------+--------+-------------+
 ```
-Successes: 1
-Trials:    1
-Probability: 0.5 (50.0%)
 ---
 ## License
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To use Rusty Finance, you can run the executable and provide the desired command
 - `depreciation`: Calculates the depreciation of an asset.
 - `irr`: Calculates the internal rate of return.
 - `variance`: Measures how much the numbers in a data set deviate from the mean.
+- `probability`: Calculates the probability of an event.
 
 ## Examples
 
@@ -390,6 +391,17 @@ Results:
 +----------+-----+
 ```
 
+## Example: Calculating Probability
+To calculate the probability of getting heads when flipping a fair coin, you can use the following command:
+```shell
+rusty-finance probability --successes 1 --trials 1
+```
+### Result
+```
+```
+Successes: 1
+Trials:    1
+Probability: 0.5 (50.0%)
 ---
 ## License
 This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,10 +328,27 @@ fn main() {
     let opts: Opts = Opts::parse();
 
     match opts.command {
-            Command::Probability(probability) => {
-            let result = calculate_probability(probability.successes, probability.trials);
-            println!("Probability: {}", result);
-       }
+        Command::Probability(probability) => {
+            let successes = probability.successes;
+            let trials = probability.trials;
+            let result = calculate_probability(successes, trials);
+
+            let mut table = Table::new();
+            table.set_titles(Row::new(vec![
+                Cell::new("Successes"),
+                Cell::new("Trials"),
+                Cell::new("Probability"),
+            ]));
+
+            table.add_row(Row::new(vec![
+                Cell::new(&successes.to_string()),
+                Cell::new(&trials.to_string()),
+                Cell::new(&format!("{:.2}%", result * 100.0)),
+            ]));
+
+            table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+            table.printstd();
+        }
         Command::IRR(irr) => {
             irr.execute();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ enum Command {
     IRR(IRR),
     Variance(Variance),
     StandardDeviation(StandardDeviation),
+    Probability(Probability),
 }
 
 #[derive(Parser, Debug)]
@@ -308,11 +309,29 @@ struct StandardDeviation {
     numbers: Vec<f64>,
 }
 
+#[derive(Parser, Debug)]
+struct Probability {
+    /// The number of successful outcomes
+    #[clap(short, long)]
+    successes: u32,
+
+    /// The number of total trials
+    #[clap(short, long)]
+    trials: u32,
+}
+
+fn calculate_probability(successes: u32, trials: u32) -> f64 {
+    (successes as f64) / (trials as f64)
+}
 
 fn main() {
     let opts: Opts = Opts::parse();
 
     match opts.command {
+            Command::Probability(probability) => {
+            let result = calculate_probability(probability.successes, probability.trials);
+            println!("Probability: {}", result);
+       }
         Command::IRR(irr) => {
             irr.execute();
         }


### PR DESCRIPTION
To calculate the probability of getting heads when flipping a fair coin, you can use the following command:
```shell
rusty-finance probability --successes 3 --trials 5
```